### PR TITLE
Downgrade vom Java 22 to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <svp.junit.version>5.11.3</svp.junit.version>
         <svp.maven-javadoc-plugin.version>3.11.1</svp.maven-javadoc-plugin.version>
         <svp.maven-surefire-plugin.version>3.5.2</svp.maven-surefire-plugin.version>
-        <svp.java-language-level>22</svp.java-language-level>
+        <svp.java-language-level>17</svp.java-language-level>
         <svp.maven-compiler-plugin.version>3.13.0</svp.maven-compiler-plugin.version>
         <svp.maven-source-plugin.version>3.3.1</svp.maven-source-plugin.version>
         <svp.maven-gpg-plugin.version>3.2.7</svp.maven-gpg-plugin.version>

--- a/readme.adoc
+++ b/readme.adoc
@@ -6,7 +6,8 @@ image:https://github.com/freiheitstools/semver-lib/actions/workflows/build-and-t
 
 '''
 
-The _Semantic Versioning Parser_ is Java library for parsing and building semantic versions according to the https://semver.org/[Semantic Version Specification].
+The _Semantic Versioning Parser_ is a Java library for parsing and building semantic versions according to the https://semver.org/[Semantic Version Specification].
+It requires Java 17 or higher.
 
 == Maven Dependency
 

--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/InternalSemanticVersionParser.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/InternalSemanticVersionParser.java
@@ -47,7 +47,7 @@ public class InternalSemanticVersionParser implements SemVerParser {
             // ignore
         }
 
-        State finalState = transitionTable.getReachedStates().getLast();
+        State finalState = transitionTable.getReachedStates().get(transitionTable.getReachedStates().size() - 1);
 
         if (finalState.isErrorState()) {
             SemanticVersionNumberElement errorLocation = errorLocationMapping.getLocationByState(finalState);

--- a/src/test/java/io/github/freiheitstools/semver/parser/implementation/SemVerFiniteStateTransitionTableTest.java
+++ b/src/test/java/io/github/freiheitstools/semver/parser/implementation/SemVerFiniteStateTransitionTableTest.java
@@ -89,7 +89,7 @@ class SemVerFiniteStateTransitionTableTest {
             // Ignore
         }
 
-        State finalState = classUnderTest.getReachedStates().getLast();
+        State finalState = classUnderTest.getReachedStates().get(classUnderTest.getReachedStates().size() - 1);
 
         assertThat(finalState.isErrorState())
                 .as("State %s is not an final error state", finalState)


### PR DESCRIPTION
Changed the Java language version used to write and to build the library to Java 17.

Java 17 is a LTS version. Java 21 is considered as to new and not as widely used enough to gain a relevant user base.