### PR TITLE
Fixed a job name in the GitHub Workflow to build the project

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     build-and-test:
-        name: 'xxxBuild and Test'
+        name: 'Build and Test'
         strategy:
             matrix:
                 version: [22, 23]


### PR DESCRIPTION
Removed the text prefix `xxx` from the name of a job in the GitHub Workflow.