### PR TITLE
Build with JDK 17->23 on all three plattforms

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,9 +12,10 @@ jobs:
         name: 'Build and Test'
         strategy:
             matrix:
-                version: [22, 23]
+                version: [17, 21, 22, 23]
+                os: [ubuntu-latest, windows-latest, macos-latest]
 
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
 
         steps:
             - name: Checkout Git Repository


### PR DESCRIPTION
To avoid any surprises with newer Java versions
or on any of the major plattforms, the project
will now be build on MacOS, Windows, and Linux
and with any JDK version from 17 up to 23.