### PR TITLE
Added Java 24 to the matrix build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,7 +12,7 @@ jobs:
         name: 'Build and Test'
         strategy:
             matrix:
-                version: [17, 21, 22, 23]
+                version: [17, 21, 22, 23, 24]
                 os: [ubuntu-latest, windows-latest, macos-latest]
 
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The semver cli will now be also built with Java 24. This should help to ensure, that the current implementation can be also built with future versions of Java.