### PR TITLE
Introduce named constants for negated transition character sets

### DIFF
--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/CharacterSets.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/CharacterSets.java
@@ -1,11 +1,11 @@
 package io.github.freiheitstools.semver.parser.implementation;
 
 /**
- * Definition of character groups like alphanumeric characters or digits used in the grammatic for
- * semantic version numbers.
+ * Definition of character groups like alphanumeric characters or digits as used in the grammatic for
+ * semantic versioning.
  */
-class CharacterSets {
-    static char TERMINAL_SIGNAL = 0x0;
+final class CharacterSets {
+    final static char TERMINAL_SIGNAL = 0x0;
 
     final static String DIGITS = "0123456789";
     final static String DOT = ".";

--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/SemVerFiniteStateTransitionTable.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/SemVerFiniteStateTransitionTable.java
@@ -2,11 +2,20 @@ package io.github.freiheitstools.semver.parser.implementation;
 
 import java.util.List;
 
-import static io.github.freiheitstools.semver.parser.implementation.State.*;
 import static io.github.freiheitstools.semver.parser.implementation.State.END_OF_SEMVER;
 import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_BUILD;
+import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_MAJOR_VERSION;
+import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_MINOR_VERSION;
 import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_PATCH_NUMBER;
 import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_PRERELEASE;
+import static io.github.freiheitstools.semver.parser.implementation.State.S00_START;
+import static io.github.freiheitstools.semver.parser.implementation.State.S01_MAJOR_STARTS_WITH_ZERO;
+import static io.github.freiheitstools.semver.parser.implementation.State.S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT;
+import static io.github.freiheitstools.semver.parser.implementation.State.S03_DOT_AFTER_MAJOR_NUMBER;
+import static io.github.freiheitstools.semver.parser.implementation.State.S04_MINOR_STARTS_WITH_ZERO;
+import static io.github.freiheitstools.semver.parser.implementation.State.S05_MINOR_STARTS_WITH_POSITIVE_DIGIT;
+import static io.github.freiheitstools.semver.parser.implementation.State.S06_DOT_AFTER_MINOR_NUMBER;
+import static io.github.freiheitstools.semver.parser.implementation.State.S07_PATCH_STARTS_WITH_POSITIVE_DIGIT;
 import static io.github.freiheitstools.semver.parser.implementation.State.S08_PATCH_STARTS_WITH_ZERO;
 import static io.github.freiheitstools.semver.parser.implementation.State.S09_AFTER_HYPHEN_BEFORE_PRERELEASE;
 import static io.github.freiheitstools.semver.parser.implementation.State.S11_PRERELEASE_AFTER_POSITIVE_DIGIT;
@@ -14,20 +23,10 @@ import static io.github.freiheitstools.semver.parser.implementation.State.S12_PR
 import static io.github.freiheitstools.semver.parser.implementation.State.S13_PRERELEASE_AFTER_ZERO;
 import static io.github.freiheitstools.semver.parser.implementation.State.S14_PRERELEASE_AFTER_DOT;
 import static io.github.freiheitstools.semver.parser.implementation.State.S15_PRERELEASE_DIGIT_LOOP;
-import static io.github.freiheitstools.semver.parser.implementation.State.S06_DOT_AFTER_MINOR_NUMBER;
-import static io.github.freiheitstools.semver.parser.implementation.State.S07_PATCH_STARTS_WITH_POSITIVE_DIGIT;
 import static io.github.freiheitstools.semver.parser.implementation.State.S16_AFTER_PLUS_BEFORE_BUILD;
 import static io.github.freiheitstools.semver.parser.implementation.State.S17_BUILD_AFTER_ALPHANUM;
 import static io.github.freiheitstools.semver.parser.implementation.State.S18_BUILD_DOT_IN_BUILD;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.ALPHA;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.ALPHANUM;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.DIGIT;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.DOT;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.END_OF_INPUT;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.HYPHEN;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.PLUS;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.POSITIVE_DIGIT;
-import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.ZERO_DIGIT;
+import static io.github.freiheitstools.semver.parser.implementation.TransitionCharSets.*;
 
 class SemVerFiniteStateTransitionTable {
     FiniteStateTransitionTable transitionTable = new FiniteStateTransitionTable();
@@ -40,7 +39,7 @@ class SemVerFiniteStateTransitionTable {
     void initFiniteStateTransitionTable() {
         /*
          * AVOID linebreaks in the statements used to configure a transition. The Python script used to
-         * extract the rules can not handle linebreaks in the statements.
+         * extract the rules cannot handle linebreaks in the statements.
          * 2024-10-20 // Oliver B. Fischer
          */
         /*
@@ -54,41 +53,41 @@ class SemVerFiniteStateTransitionTable {
         transitionTable.from(S00_START).to(S01_MAJOR_STARTS_WITH_ZERO).when(ZERO_DIGIT);
         transitionTable.from(S00_START).to(S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT).when(POSITIVE_DIGIT);
         transitionTable.from(S00_START).to(ERROR_MAJOR_VERSION).when(END_OF_INPUT);
-        transitionTable.from(S00_START).to(ERROR_MAJOR_VERSION).when(TransitionCharSet.ofNegationFor(DIGIT));
+        transitionTable.from(S00_START).to(ERROR_MAJOR_VERSION).when(NON_DIGIT);
 
         /*
          *
          */
         transitionTable.from(S01_MAJOR_STARTS_WITH_ZERO).to(S03_DOT_AFTER_MAJOR_NUMBER).when(DOT);
-        transitionTable.from(S01_MAJOR_STARTS_WITH_ZERO).to(ERROR_MAJOR_VERSION).when(TransitionCharSet.ofNegationFor(DOT));
+        transitionTable.from(S01_MAJOR_STARTS_WITH_ZERO).to(ERROR_MAJOR_VERSION).when(NOT_A_DOT);
 
         /*
          *
          */
         transitionTable.from(S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT).to(S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT).when(DIGIT);
         transitionTable.from(S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT).to(S03_DOT_AFTER_MAJOR_NUMBER).when(DOT);
-        transitionTable.from(S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT).to(ERROR_MINOR_VERSION).when(TransitionCharSet.ofNegationFor(DOT, DIGIT));
+        transitionTable.from(S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT).to(ERROR_MINOR_VERSION).when(NEITHER_DOT_DIGIT);
 
         /*
          * S3: All transitions starting from the dot between major and minor number
          */
         transitionTable.from(S03_DOT_AFTER_MAJOR_NUMBER).to(S05_MINOR_STARTS_WITH_POSITIVE_DIGIT).when(POSITIVE_DIGIT);
         transitionTable.from(S03_DOT_AFTER_MAJOR_NUMBER).to(S04_MINOR_STARTS_WITH_ZERO).when(ZERO_DIGIT);
-        transitionTable.from(S03_DOT_AFTER_MAJOR_NUMBER).to(ERROR_MINOR_VERSION).when(TransitionCharSet.ofNegationFor(DIGIT));
+        transitionTable.from(S03_DOT_AFTER_MAJOR_NUMBER).to(ERROR_MINOR_VERSION).when(NON_DIGIT);
 
         /*
          *
          */
         transitionTable.from(S04_MINOR_STARTS_WITH_ZERO).to(S06_DOT_AFTER_MINOR_NUMBER).when(DOT);
-        transitionTable.from(S04_MINOR_STARTS_WITH_ZERO).to(ERROR_MINOR_VERSION).when(TransitionCharSet.ofNegationFor(DOT));
-        transitionTable.from(S04_MINOR_STARTS_WITH_ZERO).to(ERROR_MINOR_VERSION).when(TransitionCharSet.ofNegationFor(DIGIT));
+        transitionTable.from(S04_MINOR_STARTS_WITH_ZERO).to(ERROR_MINOR_VERSION).when(NOT_A_DOT);
+        transitionTable.from(S04_MINOR_STARTS_WITH_ZERO).to(ERROR_MINOR_VERSION).when(NON_DIGIT);
 
         /*
          * All transitions from S5: The minor number starts with a positive digit
          */
         transitionTable.from(S05_MINOR_STARTS_WITH_POSITIVE_DIGIT).to(S06_DOT_AFTER_MINOR_NUMBER).when(DOT);
         transitionTable.from(S05_MINOR_STARTS_WITH_POSITIVE_DIGIT).to(S05_MINOR_STARTS_WITH_POSITIVE_DIGIT).when(DIGIT);
-        transitionTable.from(S05_MINOR_STARTS_WITH_POSITIVE_DIGIT).to(ERROR_MINOR_VERSION).when(TransitionCharSet.ofNegationFor(DOT, DIGIT));
+        transitionTable.from(S05_MINOR_STARTS_WITH_POSITIVE_DIGIT).to(ERROR_MINOR_VERSION).when(NEITHER_DOT_DIGIT);
 
         /*
          *
@@ -96,7 +95,7 @@ class SemVerFiniteStateTransitionTable {
         transitionTable.from(S06_DOT_AFTER_MINOR_NUMBER).to(S08_PATCH_STARTS_WITH_ZERO).when(ZERO_DIGIT);
         transitionTable.from(S06_DOT_AFTER_MINOR_NUMBER).to(S07_PATCH_STARTS_WITH_POSITIVE_DIGIT).when(POSITIVE_DIGIT);
         transitionTable.from(S06_DOT_AFTER_MINOR_NUMBER).to(ERROR_PATCH_NUMBER).when(END_OF_INPUT);
-        transitionTable.from(S06_DOT_AFTER_MINOR_NUMBER).to(ERROR_PATCH_NUMBER).when(TransitionCharSet.ofNegationFor(DIGIT));
+        transitionTable.from(S06_DOT_AFTER_MINOR_NUMBER).to(ERROR_PATCH_NUMBER).when(NON_DIGIT);
 
         /*
          * All transitions from S7: The patch number starts with 1..9
@@ -122,7 +121,7 @@ class SemVerFiniteStateTransitionTable {
         transitionTable.from(S09_AFTER_HYPHEN_BEFORE_PRERELEASE).to(S13_PRERELEASE_AFTER_ZERO).when(ZERO_DIGIT);
         transitionTable.from(S09_AFTER_HYPHEN_BEFORE_PRERELEASE).to(S11_PRERELEASE_AFTER_POSITIVE_DIGIT).when(POSITIVE_DIGIT);
         transitionTable.from(S09_AFTER_HYPHEN_BEFORE_PRERELEASE).to(ERROR_PRERELEASE).when(END_OF_INPUT);
-        transitionTable.from(S09_AFTER_HYPHEN_BEFORE_PRERELEASE).to(ERROR_PRERELEASE).when(TransitionCharSet.ofNegationFor(ALPHA, ZERO_DIGIT, POSITIVE_DIGIT));
+        transitionTable.from(S09_AFTER_HYPHEN_BEFORE_PRERELEASE).to(ERROR_PRERELEASE).when(NEITHER_ALPHA_ZERO_DIGIT);
 
         /*
          *
@@ -138,7 +137,7 @@ class SemVerFiniteStateTransitionTable {
         transitionTable.from(S12_PRERELEASE_AFTER_ALPHA).to(END_OF_SEMVER).when(END_OF_INPUT);
         transitionTable.from(S12_PRERELEASE_AFTER_ALPHA).to(S12_PRERELEASE_AFTER_ALPHA).when(ALPHANUM);
         transitionTable.from(S12_PRERELEASE_AFTER_ALPHA).to(S14_PRERELEASE_AFTER_DOT).when(DOT);
-        transitionTable.from(S12_PRERELEASE_AFTER_ALPHA).to(ERROR_PRERELEASE).when(TransitionCharSet.ofNegationFor(ALPHA, DOT, PLUS));
+        transitionTable.from(S12_PRERELEASE_AFTER_ALPHA).to(ERROR_PRERELEASE).when(NEITHER_ALPHA_DOT_PLUS);
         transitionTable.from(S12_PRERELEASE_AFTER_ALPHA).to(S16_AFTER_PLUS_BEFORE_BUILD).when(PLUS);
 
         /*
@@ -149,7 +148,7 @@ class SemVerFiniteStateTransitionTable {
         transitionTable.from(S13_PRERELEASE_AFTER_ZERO).to(S15_PRERELEASE_DIGIT_LOOP).when(DIGIT);
         transitionTable.from(S13_PRERELEASE_AFTER_ZERO).to(S12_PRERELEASE_AFTER_ALPHA).when(ALPHA);
         transitionTable.from(S13_PRERELEASE_AFTER_ZERO).to(S16_AFTER_PLUS_BEFORE_BUILD).when(PLUS);
-        transitionTable.from(S13_PRERELEASE_AFTER_ZERO).to(ERROR_PRERELEASE).when(TransitionCharSet.ofNegationFor(DIGIT, ALPHA, HYPHEN, DOT, PLUS));
+        transitionTable.from(S13_PRERELEASE_AFTER_ZERO).to(ERROR_PRERELEASE).when(NEITHER_DIGIT_ALPHA_HYPHEN_DOT_PLUS);
 
         /*
          *
@@ -166,14 +165,14 @@ class SemVerFiniteStateTransitionTable {
         transitionTable.from(S15_PRERELEASE_DIGIT_LOOP).to(S15_PRERELEASE_DIGIT_LOOP).when(ZERO_DIGIT);
         transitionTable.from(S15_PRERELEASE_DIGIT_LOOP).to(S12_PRERELEASE_AFTER_ALPHA).when(ALPHA);
         transitionTable.from(S15_PRERELEASE_DIGIT_LOOP).to(ERROR_PRERELEASE).when(END_OF_INPUT);
-        transitionTable.from(S15_PRERELEASE_DIGIT_LOOP).to(ERROR_PRERELEASE).when(TransitionCharSet.ofNegationFor(ZERO_DIGIT, ALPHA, END_OF_INPUT));
+        transitionTable.from(S15_PRERELEASE_DIGIT_LOOP).to(ERROR_PRERELEASE).when(NO_ZERO_ALPHA_EOI);
 
         /*
          *
          */
         transitionTable.from(S16_AFTER_PLUS_BEFORE_BUILD).to(ERROR_BUILD).when(END_OF_INPUT);
         transitionTable.from(S16_AFTER_PLUS_BEFORE_BUILD).to(S17_BUILD_AFTER_ALPHANUM).when(ALPHANUM);
-        transitionTable.from(S16_AFTER_PLUS_BEFORE_BUILD).to(ERROR_BUILD).when(TransitionCharSet.ofNegationFor(ALPHANUM));
+        transitionTable.from(S16_AFTER_PLUS_BEFORE_BUILD).to(ERROR_BUILD).when(NO_ALPHANUM);
 
         /*
          *
@@ -181,7 +180,7 @@ class SemVerFiniteStateTransitionTable {
         transitionTable.from(S17_BUILD_AFTER_ALPHANUM).to(END_OF_SEMVER).when(END_OF_INPUT);
         transitionTable.from(S17_BUILD_AFTER_ALPHANUM).to(S17_BUILD_AFTER_ALPHANUM).when(ALPHANUM);
         transitionTable.from(S17_BUILD_AFTER_ALPHANUM).to(S18_BUILD_DOT_IN_BUILD).when(DOT);
-        transitionTable.from(S17_BUILD_AFTER_ALPHANUM).to(ERROR_BUILD).when(TransitionCharSet.ofNegationFor(ALPHANUM, DOT));
+        transitionTable.from(S17_BUILD_AFTER_ALPHANUM).to(ERROR_BUILD).when(NEITHER_ALPHANUM_DOT);
 
         /*
          *

--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/StateToLocationMapping.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/StateToLocationMapping.java
@@ -5,41 +5,58 @@ import io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement;
 import java.util.Hashtable;
 import java.util.function.BiFunction;
 
-import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_BUILD;
-import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_MAJOR_VERSION;
-import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_MINOR_VERSION;
-import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_PATCH_NUMBER;
-import static io.github.freiheitstools.semver.parser.implementation.State.ERROR_PRERELEASE;
+import static io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement.*;
+import static io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement.DOT_BETWEEN_MAJOR_VERSION_AND_MINOR_VERSION;
+import static io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement.DOT_BETWEEN_MINOR_VERSION_AND_PATCH_VERSION;
+import static io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement.HYPHEN_BETWEEN_PATCH_VERSION_AND_PRERELEASE_VERSION;
+import static io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement.MAJOR_VERSION;
+import static io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement.MINOR_VERSION;
+import static io.github.freiheitstools.semver.parser.api.SemanticVersionNumberElement.PATCH_VERSION;
+import static io.github.freiheitstools.semver.parser.implementation.State.*;
+import static io.github.freiheitstools.semver.parser.implementation.State.S01_MAJOR_STARTS_WITH_ZERO;
+import static io.github.freiheitstools.semver.parser.implementation.State.S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT;
+import static io.github.freiheitstools.semver.parser.implementation.State.S03_DOT_AFTER_MAJOR_NUMBER;
+import static io.github.freiheitstools.semver.parser.implementation.State.S04_MINOR_STARTS_WITH_ZERO;
+import static io.github.freiheitstools.semver.parser.implementation.State.S05_MINOR_STARTS_WITH_POSITIVE_DIGIT;
+import static io.github.freiheitstools.semver.parser.implementation.State.S06_DOT_AFTER_MINOR_NUMBER;
+import static io.github.freiheitstools.semver.parser.implementation.State.S07_PATCH_STARTS_WITH_POSITIVE_DIGIT;
+import static io.github.freiheitstools.semver.parser.implementation.State.S08_PATCH_STARTS_WITH_ZERO;
+import static io.github.freiheitstools.semver.parser.implementation.State.S09_AFTER_HYPHEN_BEFORE_PRERELEASE;
+import static io.github.freiheitstools.semver.parser.implementation.State.S10_PRERELEASE_AFTER_DOT;
+import static io.github.freiheitstools.semver.parser.implementation.State.S11_PRERELEASE_AFTER_POSITIVE_DIGIT;
 
+/**
+ * Maintains the mapping between states and semantic version number elements.
+ */
 class StateToLocationMapping {
     private static Hashtable<State, SemanticVersionNumberElement> mapping = new Hashtable<>();
 
     static {
-        mapping.put(State.S00_START, SemanticVersionNumberElement.MAJOR_VERSION);
-        mapping.put(State.S01_MAJOR_STARTS_WITH_ZERO, SemanticVersionNumberElement.MAJOR_VERSION);
-        mapping.put(State.S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT, SemanticVersionNumberElement.MAJOR_VERSION);
-        mapping.put(State.S03_DOT_AFTER_MAJOR_NUMBER, SemanticVersionNumberElement.DOT_BETWEEN_MAJOR_VERSION_AND_MINOR_VERSION);
-        mapping.put(State.S04_MINOR_STARTS_WITH_ZERO, SemanticVersionNumberElement.MINOR_VERSION);
-        mapping.put(State.S05_MINOR_STARTS_WITH_POSITIVE_DIGIT, SemanticVersionNumberElement.MINOR_VERSION);
-        mapping.put(State.S06_DOT_AFTER_MINOR_NUMBER, SemanticVersionNumberElement.DOT_BETWEEN_MINOR_VERSION_AND_PATCH_VERSION);
-        mapping.put(State.S07_PATCH_STARTS_WITH_POSITIVE_DIGIT, SemanticVersionNumberElement.PATCH_VERSION);
-        mapping.put(State.S08_PATCH_STARTS_WITH_ZERO, SemanticVersionNumberElement.PATCH_VERSION);
-        mapping.put(State.S09_AFTER_HYPHEN_BEFORE_PRERELEASE, SemanticVersionNumberElement.HYPHEN_BETWEEN_PATCH_VERSION_AND_PRERELEASE_VERSION);
-        mapping.put(State.S10_PRERELEASE_AFTER_DOT, SemanticVersionNumberElement.PRERELEASE_VERSION);
-        mapping.put(State.S11_PRERELEASE_AFTER_POSITIVE_DIGIT, SemanticVersionNumberElement.PRERELEASE_VERSION);
-        mapping.put(State.S12_PRERELEASE_AFTER_ALPHA, SemanticVersionNumberElement.PRERELEASE_VERSION);
-        mapping.put(State.S13_PRERELEASE_AFTER_ZERO, SemanticVersionNumberElement.PRERELEASE_VERSION);
-        mapping.put(State.S14_PRERELEASE_AFTER_DOT, SemanticVersionNumberElement.PRERELEASE_VERSION);
-        mapping.put(State.S15_PRERELEASE_DIGIT_LOOP, SemanticVersionNumberElement.PRERELEASE_VERSION);
-        mapping.put(State.S16_AFTER_PLUS_BEFORE_BUILD, SemanticVersionNumberElement.PLUS_BETWEEN_PRERELEASE_VERSION_AND_VERSION_VERSION);
-        mapping.put(State.S17_BUILD_AFTER_ALPHANUM, SemanticVersionNumberElement.BUILD_VERSION);
-        mapping.put(State.S18_BUILD_DOT_IN_BUILD, SemanticVersionNumberElement.BUILD_VERSION);
+        mapping.put(S00_START, MAJOR_VERSION);
+        mapping.put(S01_MAJOR_STARTS_WITH_ZERO, MAJOR_VERSION);
+        mapping.put(S02_MAJOR_STARTS_WITH_POSITIVE_DIGIT, MAJOR_VERSION);
+        mapping.put(S03_DOT_AFTER_MAJOR_NUMBER, DOT_BETWEEN_MAJOR_VERSION_AND_MINOR_VERSION);
+        mapping.put(S04_MINOR_STARTS_WITH_ZERO, MINOR_VERSION);
+        mapping.put(S05_MINOR_STARTS_WITH_POSITIVE_DIGIT, MINOR_VERSION);
+        mapping.put(S06_DOT_AFTER_MINOR_NUMBER, DOT_BETWEEN_MINOR_VERSION_AND_PATCH_VERSION);
+        mapping.put(S07_PATCH_STARTS_WITH_POSITIVE_DIGIT, PATCH_VERSION);
+        mapping.put(S08_PATCH_STARTS_WITH_ZERO, PATCH_VERSION);
+        mapping.put(S09_AFTER_HYPHEN_BEFORE_PRERELEASE, HYPHEN_BETWEEN_PATCH_VERSION_AND_PRERELEASE_VERSION);
+        mapping.put(S10_PRERELEASE_AFTER_DOT, PRERELEASE_VERSION);
+        mapping.put(S11_PRERELEASE_AFTER_POSITIVE_DIGIT, PRERELEASE_VERSION);
+        mapping.put(S12_PRERELEASE_AFTER_ALPHA, PRERELEASE_VERSION);
+        mapping.put(S13_PRERELEASE_AFTER_ZERO, PRERELEASE_VERSION);
+        mapping.put(S14_PRERELEASE_AFTER_DOT, PRERELEASE_VERSION);
+        mapping.put(S15_PRERELEASE_DIGIT_LOOP, PRERELEASE_VERSION);
+        mapping.put(S16_AFTER_PLUS_BEFORE_BUILD, PLUS_BETWEEN_PRERELEASE_VERSION_AND_VERSION_VERSION);
+        mapping.put(S17_BUILD_AFTER_ALPHANUM, BUILD_VERSION);
+        mapping.put(S18_BUILD_DOT_IN_BUILD, BUILD_VERSION);
 
-        mapping.put(ERROR_MAJOR_VERSION, SemanticVersionNumberElement.MAJOR_VERSION);
-        mapping.put(ERROR_MINOR_VERSION, SemanticVersionNumberElement.MINOR_VERSION);
-        mapping.put(ERROR_PATCH_NUMBER, SemanticVersionNumberElement.PATCH_VERSION);
-        mapping.put(ERROR_PRERELEASE, SemanticVersionNumberElement.PRERELEASE_VERSION);
-        mapping.put(ERROR_BUILD, SemanticVersionNumberElement.BUILD_VERSION);
+        mapping.put(ERROR_MAJOR_VERSION, MAJOR_VERSION);
+        mapping.put(ERROR_MINOR_VERSION, MINOR_VERSION);
+        mapping.put(ERROR_PATCH_NUMBER, PATCH_VERSION);
+        mapping.put(ERROR_PRERELEASE, PRERELEASE_VERSION);
+        mapping.put(ERROR_BUILD, BUILD_VERSION);
     };
 
     SemanticVersionNumberElement getLocationByState(State state) {

--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/TerminalNodeReachedException.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/TerminalNodeReachedException.java
@@ -1,5 +1,9 @@
 package io.github.freiheitstools.semver.parser.implementation;
 
+/**
+ * Exception thrown when a terminal state is reached during state machine processing
+ * while input is still available.
+ */
 class TerminalNodeReachedException extends RuntimeException {
 
     private final State state;

--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/TransitionCharSet.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/TransitionCharSet.java
@@ -3,11 +3,12 @@ package io.github.freiheitstools.semver.parser.implementation;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
-/*
-    todo Der Name muss angepasst werden wegen dem negativen bla bla bla
+/**
+ * Represents a set of characters that are valid for triggering a transition
+ * in a state machine during the parsing of a semantic version.
  */
 class TransitionCharSet {
-    private char[] validChars;
+    private final char[] validChars;
 
     public TransitionCharSet(char[] validChars) {
         this.validChars = validChars;

--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/TransitionCharSets.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/TransitionCharSets.java
@@ -1,5 +1,9 @@
 package io.github.freiheitstools.semver.parser.implementation;
 
+
+/**
+ * Set of predefined transition character sets to be used in the parser.
+ */
 final class TransitionCharSets {
     static final TransitionCharSet PLUS = TransitionCharSet.of(CharacterSets.PLUS);
     static final TransitionCharSet DIGIT = TransitionCharSet.of(CharacterSets.DIGITS);
@@ -10,4 +14,13 @@ final class TransitionCharSets {
     static final TransitionCharSet ALPHA = TransitionCharSet.of(CharacterSets.ALPHA);
     static final TransitionCharSet ALPHANUM = TransitionCharSet.of(CharacterSets.ALPHANUMERIC);
     static final TransitionCharSet END_OF_INPUT = TransitionCharSet.of(CharacterSets.TERMINAL);
+    static final TransitionCharSet NON_DIGIT = TransitionCharSet.ofNegationFor(DIGIT);
+    static final TransitionCharSet NOT_A_DOT = TransitionCharSet.ofNegationFor(DOT);
+    static final TransitionCharSet NEITHER_ALPHA_DOT_PLUS = TransitionCharSet.ofNegationFor(ALPHA, DOT, PLUS);
+    static final TransitionCharSet NEITHER_DOT_DIGIT = TransitionCharSet.ofNegationFor(DOT, DIGIT);
+    static final TransitionCharSet NEITHER_DIGIT_ALPHA_HYPHEN_DOT_PLUS = TransitionCharSet.ofNegationFor(DIGIT, ALPHA, HYPHEN, DOT, PLUS);
+    static final TransitionCharSet NEITHER_ALPHA_ZERO_DIGIT = TransitionCharSet.ofNegationFor(ALPHA, ZERO_DIGIT, POSITIVE_DIGIT);
+    static final TransitionCharSet NEITHER_ALPHANUM_DOT = TransitionCharSet.ofNegationFor(ALPHANUM, DOT);
+    static final TransitionCharSet NO_ALPHANUM = TransitionCharSet.ofNegationFor(ALPHANUM);
+    static final TransitionCharSet NO_ZERO_ALPHA_EOI = TransitionCharSet.ofNegationFor(ZERO_DIGIT, ALPHA, END_OF_INPUT);
 }


### PR DESCRIPTION
Replace inline TransitionCharSet.ofNegationFor() calls with predefined named constants in TransitionCharSets (e.g., NON_DIGIT, NOT_A_DOT, NEITHER_DOT_DIGIT). This improves readability of the state transition table and centralizes character set definitions.

Additional cleanup:
- Add Javadoc to TransitionCharSet, TransitionCharSets, StateToLocationMapping, and TerminalNodeReachedException
- Use static imports to reduce verbosity in StateToLocationMapping
- Mark CharacterSets and TransitionCharSet.validChars as final