### PR TITLE
Fixed configuration of the PIT plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
                 <configuration>
-                    <coverageThreshold>${svp.pitest-target.coverage}</coverageThreshold>
+                    <mutationThreshold>${svp.pitest-target.coverage}</mutationThreshold>
                     <skip>${svp.pitest.skip}</skip>
                 </configuration>
                 <executions>


### PR DESCRIPTION
The plugin was checking the line coverage,
not the mutation coverage. This was been fixed.