### PR TITLE
Removed duplicate HYPHEN in ALPHANUMERIC character set

### DIFF
--- a/src/main/java/io/github/freiheitstools/semver/parser/implementation/CharacterSets.java
+++ b/src/main/java/io/github/freiheitstools/semver/parser/implementation/CharacterSets.java
@@ -27,7 +27,7 @@ final class CharacterSets {
         ZERO = "0";
 
         ALPHA = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" + HYPHEN;
-        ALPHANUMERIC = ALPHA + HYPHEN + DIGITS + HYPHEN;
+        ALPHANUMERIC = ALPHA + DIGITS;
         TERMINAL = "" + TERMINAL_SIGNAL;
     }
 }


### PR DESCRIPTION
Removed not needed duplicate HYPEN the character
set ALPHANUMERIC.